### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules


### PR DESCRIPTION
A pasta node_modules é a maior responsável por deixar os projetos em NodeJS gigantescos. Como essa pasta é facilmente recriada ao rodar npm/yarn install, pode ser excluída do versionamento git.